### PR TITLE
Fix delete endpoint.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@
 /* jshint node: true */
 'use strict';
 
-var _ = require('lodash');
 var bedrock = require('bedrock');
 var BedrockError = bedrock.util.BedrockError;
 var config = bedrock.config;
@@ -12,6 +11,7 @@ var brPermission = require('bedrock-permission');
 var brPassport = require('bedrock-passport');
 var database = require('bedrock-mongodb');
 var ensureAuthenticated = brPassport.ensureAuthenticated;
+var util = require('util');
 var validate = require('bedrock-validation').validate;
 
 require('bedrock-express');
@@ -26,7 +26,6 @@ bedrock.events.on('bedrock.configure', function() {
 
 bedrock.events.on('bedrock-express.configure.routes', function(app) {
   var permissionsBasePath = config['permission-http'].routes.permissions;
-  var permissionsBaseUrl = config.server.baseUri + permissionsBasePath;
   var rolesBasePath = config['permission-http'].routes.roles;
 
   /**
@@ -123,7 +122,7 @@ bedrock.events.on('bedrock-express.configure.routes', function(app) {
    */
   app.delete(
     rolesBasePath + '/:id', ensureAuthenticated, function(req, res, next) {
-    var roleId = req.params.id;
+    var roleId = createRoleId(req.params.id);
     brPermission.removeRole(req.user.identity, roleId, function(err, result) {
       if(err) {
         return next(err);
@@ -132,6 +131,18 @@ bedrock.events.on('bedrock-express.configure.routes', function(app) {
     });
   });
 
+  /**
+   * Creates a Role ID URL from the given ID.
+   *
+   * @param id the ID to use.
+   *
+   * @return the role ID URL for the role.
+   */
+  function createRoleId(id) {
+    return util.format(
+      '%s%s/%s', bedrock.config.server.baseUri, rolesBasePath,
+      encodeURIComponent(id));
+  }
 }); // end configure routes
 
 // add a permission table to the session data

--- a/package.json
+++ b/package.json
@@ -17,10 +17,6 @@
     "url": "https://github.com/digitalbazaar/bedrock-permission-http/issues"
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-permission-http",
-  "dependencies": {
-    "async": "^1.4.2",
-    "lodash": "^4.1.0"
-  },
   "peerDependencies": {
     "bedrock": "^1.0.6",
     "bedrock-express": "^2.0.3",

--- a/schemas/services.role.js
+++ b/schemas/services.role.js
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2016 Digital Bazaar, Inc. All rights reserved.
  */
-var constants = require('bedrock').config.constants;
 var schemas = require('bedrock-validation').schemas;
 
 var postRole = {


### PR DESCRIPTION
In the `role` collection, we have role IDs that are strings and role IDs that are URLs.

Prior to this PR, there is no way to delete a role with an ID that is a URL.

A user created role looks like this:
```
{
    "_id": ObjectID("583c32fb34ba8502105f06d1"),
    "id": "e9d0689481b05a1183600353b6481d085390735b4c",
    "role": {
        "label": "blip",
        "comment": "blip",
        "sysPermission": [
            "PERMISSION_ADMIN"
        ],
        "id": "https://issuer.foo.dev:23443/roles/70df53c3-467a-4758-a6f3-0060e78a7815"
    },
    "meta": {
        "created": 1480340219120,
        "updated": 1480340219120
    }
}
```

A role that is defined in the config looks like this:
```
{
    "_id": ObjectID("583c373a7b96383e12623583"),
    "id": "c8db0e5db1276de0a8159ad1c66a2204aa62f3971a",
    "role": {
        "id": "foo.credential.issuer",
        "label": "Credential Issuer",
        "comment": "Role for credential issuers.",
        "sysPermission": [
            "CREDENTIAL_INSERT",
            "CREDENTIAL_ISSUE"
        ],
        "permanent": true
    },
    "meta": {
        "created": 1480341306887,
        "updated": 1480341306887
    }
}
```
